### PR TITLE
enable vs-code-rest client in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,8 @@
 		"esbenp.prettier-vscode",
 		"gruntfuggly.todo-tree",
 		"ms-vscode.js-debug-nightly",
-		"sapse.vscode-cds"
+		"sapse.vscode-cds",
+		"humao.rest-client"
 	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.


### PR DESCRIPTION
Adds the vs-code extension http-rest to the devcontainer. We can now use the REST client also inside the docker devcontainer.