### PR TITLE
hdi-shared not offered in hanatrial

### DIFF
--- a/cf.mtaext
+++ b/cf.mtaext
@@ -5,4 +5,4 @@ extends: bookshop-demo
 resources:
   - name: bookshop-demo-db-service
     parameters:
-      service: hanatrial
+      service: hana # or 'hanatrial' on trial landscapes


### PR DESCRIPTION
Trying the deployment on a newly made trial account today I was getting an error of hdi-shared not found in hanatrial.  Seems like hdi-shared is not offered under hanatrial, only under hana. changing this file following https://answers.sap.com/questions/13360086/service-sap-hana-schemas-hdi-containers-trial-do-n.html did the trick