### PR TITLE
feat: Add dragdrop to table and update count

### DIFF
--- a/app/webapp/roleUI5latest/webapp/ext/ListReportExt.controller.js
+++ b/app/webapp/roleUI5latest/webapp/ext/ListReportExt.controller.js
@@ -1,0 +1,79 @@
+sap.ui.define(
+  [
+    'sap/ui/core/mvc/ControllerExtension',
+    'sap/ui/core/dnd/DragInfo',
+    'sap/ui/core/dnd/DropInfo',
+    'sap/ui/mdc/enums/TableSelectionMode',
+  ],
+  function (ControllerExtension, DragInfo, DropInfo, TableSelectionMode) {
+    'use strict';
+    return ControllerExtension.extend('roleUI5latest.ext.ListReportExt', {
+      addDragAndDrop: function () {
+        const table = this.base
+          .getView()
+          .byId(
+            'roleUI5latest::RolesList--fe::table::Roles::LineItem-innerTable'
+          );
+        this._enableDragAndDrop(table);
+      },
+
+      _enableDragAndDrop: function (table) {
+        // set singleselectmaster
+        table.setMode('SingleSelectMaster');
+        // Enable drag and drop mode for the table
+        table.addDragDropConfig(
+          new DragInfo({
+            sourceAggregation: 'items',
+            groupName: 'DRAG_DROP_NAME',
+          })
+        );
+
+        table.addDragDropConfig(
+          new DropInfo({
+            targetAggregation: 'items',
+            dropPosition: 'Between',
+            drop: this._onTableDrop.bind(this),
+            groupName: 'DRAG_DROP_NAME',
+          })
+        );
+      },
+
+      // Handler for drop event
+      _onTableDrop: function (oEvent) {
+        var draggedControl = oEvent.getParameter('draggedControl');
+        var droppedControl = oEvent.getParameter('droppedControl');
+        var dropPosition = oEvent.getParameter('dropPosition');
+        var table = draggedControl.getParent();
+        var rows = table.getItems();
+        var draggedIndex = rows.indexOf(draggedControl);
+        var droppedIndex = rows.indexOf(droppedControl);
+
+        // Adjust the dropped index based on the drop position
+        if (dropPosition === 'After') {
+          droppedIndex++;
+        }
+
+        const count = droppedIndex + 1;
+
+        // call action countUp with OData V4
+        const model = oEvent
+          .getParameter('draggedControl')
+          .getBindingContext()
+          .getModel();
+        const context = oEvent
+          .getParameter('draggedControl')
+          .getBindingContext();
+        const boundAction = model.bindContext(
+          'AdminService.setCount(...)',
+          context
+        );
+        // set parameter count
+        boundAction.setParameter('count', count);
+        boundAction.execute();
+
+        // refresh table
+        table.getBinding('items').refresh();
+      },
+    });
+  }
+);

--- a/app/webapp/roleUI5latest/webapp/manifest.json
+++ b/app/webapp/roleUI5latest/webapp/manifest.json
@@ -78,6 +78,15 @@
         }
       }
     },
+    "extends": {
+      "extensions": {
+          "sap.ui.controllerExtensions": {
+              "sap.fe.templates.ListReport.ListReportController": {
+                  "controllerName": "roleUI5latest.ext.ListReportExt"
+              }
+          }
+      }
+  },
     "routing": {
       "routes": [
         {
@@ -112,7 +121,8 @@
                 "@com.sap.vocabularies.UI.v1.LineItem": {
                   "tableSettings": {
                     "selectAll": true,
-                    "enableMassEdit": true
+                    "enableMassEdit": true,
+                    "beforeRebindTable": ".extension.roleUI5latest.ext.ListReportExt.addDragAndDrop"
                   }
                 }
               }

--- a/srv/admin-service.cds
+++ b/srv/admin-service.cds
@@ -110,6 +110,8 @@ service AdminService @(
       action countUp()                                                                  returns Roles;
       @(Common.SideEffects.TargetEntities: ['/AdminService.EntityContainer/Roles'])
       action countDown()                                                                returns Roles;
+      @(Common.SideEffects.TargetEntities: ['/AdminService.EntityContainer/Roles'])
+      action setCount(count : Integer)                                                                returns Roles;
     };
 
   //------- auto-exposed --------


### PR DESCRIPTION
- add ability dragDrop to table in List Report (not stable, might need to change something here)
- create new action to set count and recount (code in admin-service is LLM generate, but works)
- call action when dropping row

![bookshopdragdrop](https://github.com/user-attachments/assets/85efea8a-c57d-4ba1-ab9e-2859f901c49a)
